### PR TITLE
Ruby 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gemfile: [ sidekiq6, sidekiq7 ]
+        sidekiq: [ sidekiq6, sidekiq7 ]
+        ruby: [ 2.7.5, 3.0.3 ]
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
-      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/Gemfile-${{ matrix.gemfile }}
+      BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/Gemfile-${{ matrix.sidekiq }}
 
     services:
       redis:
@@ -24,7 +25,7 @@ jobs:
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.5'
+          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
 
       - name: Run tests

--- a/lib/sidekiq_smart_cache/model.rb
+++ b/lib/sidekiq_smart_cache/model.rb
@@ -60,7 +60,7 @@ module SidekiqSmartCache::Model
         else
           promise_args[:klass] = self.name
         end
-        SidekiqSmartCache::Promise.new(promise_args)
+        SidekiqSmartCache::Promise.new(**promise_args)
       end
 
       if_available_method = ->(*args) do

--- a/lib/sidekiq_smart_cache/redis.rb
+++ b/lib/sidekiq_smart_cache/redis.rb
@@ -25,8 +25,8 @@ module SidekiqSmartCache
     def wait_for_done_message(key, timeout)
       return true if defined?(Sidekiq::Testing) && Sidekiq::Testing.inline?
 
-      if brpop(job_completion_key(key), timeout.to_i)
-        # log_msg("got done message for #{key}")
+      if brpop(job_completion_key(key), timeout: timeout.to_i)
+          # log_msg("got done message for #{key}")
         send_done_message(key) # put it back for any other readers
         true
       end


### PR DESCRIPTION
Add support for ruby 3

Some wonky differences in how variable length argument lists get passed into methods between ruby 2.7 and 3.0 lead to surprises with the rest-client gem.  

This papers it over.