### PR TITLE
Adding support for sidekiq 7.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sidekiq: [ sidekiq6, sidekiq7 ]
+        sidekiq: [ sidekiq6, sidekiq7, sidekiq7.2 ]
         ruby: [ 2.7.5, 3.0.3 ]
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/gemfiles/Gemfile-sidekiq7.2
+++ b/gemfiles/Gemfile-sidekiq7.2
@@ -1,0 +1,17 @@
+source 'https://rubygems.org'
+
+# Declare your gem's dependencies in sidekiq_smart_cache.gemspec.
+# Bundler will treat runtime dependencies like base dependencies, and
+# development dependencies will be added by default to the :development group.
+gemspec path: '..'
+gem 'sidekiq', '>= 7.2.0'
+
+# Declare any dependencies that are still in development here instead of in
+# your gemspec. These might include edge Rails or gems from your path or
+# Git. Remember to move these dependencies to your gemspec before releasing
+# your gem to rubygems.org.
+group :development, :test do
+  gem 'rails', '7.0.7.2'
+  # To use a debugger
+  gem 'pry'
+end

--- a/gemfiles/Gemfile-sidekiq7.2.lock
+++ b/gemfiles/Gemfile-sidekiq7.2.lock
@@ -1,0 +1,179 @@
+PATH
+  remote: ..
+  specs:
+    sidekiq_smart_cache (0.1.0)
+      sidekiq
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actioncable (7.0.7.2)
+      actionpack (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (7.0.7.2)
+      actionpack (= 7.0.7.2)
+      activejob (= 7.0.7.2)
+      activerecord (= 7.0.7.2)
+      activestorage (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      mail (>= 2.7.1)
+      net-imap
+      net-pop
+      net-smtp
+    actionmailer (7.0.7.2)
+      actionpack (= 7.0.7.2)
+      actionview (= 7.0.7.2)
+      activejob (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      mail (~> 2.5, >= 2.5.4)
+      net-imap
+      net-pop
+      net-smtp
+      rails-dom-testing (~> 2.0)
+    actionpack (7.0.7.2)
+      actionview (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      rack (~> 2.0, >= 2.2.4)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (7.0.7.2)
+      actionpack (= 7.0.7.2)
+      activerecord (= 7.0.7.2)
+      activestorage (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      globalid (>= 0.6.0)
+      nokogiri (>= 1.8.5)
+    actionview (7.0.7.2)
+      activesupport (= 7.0.7.2)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activejob (7.0.7.2)
+      activesupport (= 7.0.7.2)
+      globalid (>= 0.3.6)
+    activemodel (7.0.7.2)
+      activesupport (= 7.0.7.2)
+    activerecord (7.0.7.2)
+      activemodel (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+    activestorage (7.0.7.2)
+      actionpack (= 7.0.7.2)
+      activejob (= 7.0.7.2)
+      activerecord (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      marcel (~> 1.0)
+      mini_mime (>= 1.1.0)
+    activesupport (7.0.7.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    builder (3.2.4)
+    coderay (1.1.3)
+    concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
+    crass (1.0.6)
+    date (3.3.4)
+    erubi (1.12.0)
+    globalid (1.2.1)
+      activesupport (>= 6.1)
+    i18n (1.14.1)
+      concurrent-ruby (~> 1.0)
+    loofah (2.22.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (1.0.2)
+    method_source (1.0.0)
+    mini_mime (1.1.5)
+    minitest (5.20.0)
+    net-imap (0.4.8)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.2)
+      timeout
+    net-smtp (0.4.0)
+      net-protocol
+    nio4r (2.7.0)
+    nokogiri (1.15.5-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.15.5-x86_64-linux)
+      racc (~> 1.4)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.7.3)
+    rack (2.2.8)
+    rack-test (2.1.0)
+      rack (>= 1.3)
+    rails (7.0.7.2)
+      actioncable (= 7.0.7.2)
+      actionmailbox (= 7.0.7.2)
+      actionmailer (= 7.0.7.2)
+      actionpack (= 7.0.7.2)
+      actiontext (= 7.0.7.2)
+      actionview (= 7.0.7.2)
+      activejob (= 7.0.7.2)
+      activemodel (= 7.0.7.2)
+      activerecord (= 7.0.7.2)
+      activestorage (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      bundler (>= 1.15.0)
+      railties (= 7.0.7.2)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    railties (7.0.7.2)
+      actionpack (= 7.0.7.2)
+      activesupport (= 7.0.7.2)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.1.0)
+    redis-client (0.19.0)
+      connection_pool
+    sidekiq (7.2.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      rack (>= 2.2.4)
+      redis-client (>= 0.14.0)
+    sqlite3 (1.6.9-x86_64-darwin)
+    sqlite3 (1.6.9-x86_64-linux)
+    thor (1.3.0)
+    timeout (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    websocket-driver (0.7.6)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+    zeitwerk (2.6.12)
+
+PLATFORMS
+  x86_64-darwin-22
+  x86_64-darwin-23
+  x86_64-linux
+
+DEPENDENCIES
+  pry
+  rails (= 7.0.7.2)
+  sidekiq (>= 7.2.0)
+  sidekiq_smart_cache!
+  sqlite3
+
+BUNDLED WITH
+   2.2.33

--- a/test/redis_test.rb
+++ b/test/redis_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+class RedisTest < ActiveSupport::TestCase
+  setup do
+    SidekiqSmartCache.redis.flushdb
+  end
+
+  test 'basic set and get' do
+    assert_nil SidekiqSmartCache.redis.get('narf')
+
+    SidekiqSmartCache.redis.set('narf', 'blah')
+    assert_equal SidekiqSmartCache.redis.get('narf'), 'blah'
+  end
+
+  test 'arrayify_args' do
+    assert_equal SidekiqSmartCache.redis.arrayify_args(['bar', { nx: true, ex: 60 }]), %w[bar NX EX 60]
+  end
+
+  test 'setnx' do
+    assert_nil SidekiqSmartCache.redis.get('narf')
+
+    # setnx returns true when the key is being set
+    assert SidekiqSmartCache.redis.set('narf', 'blah', nx: true)
+    assert_equal SidekiqSmartCache.redis.get('narf'), 'blah'
+
+    # returns false when its already set
+    refute SidekiqSmartCache.redis.set('narf', 'bunk', nx: true)
+    assert_equal SidekiqSmartCache.redis.get('narf'), 'blah'
+
+  end
+
+  test 'expiring keys' do
+    assert_nil SidekiqSmartCache.redis.get('narf')
+
+    assert SidekiqSmartCache.redis.set('narf', 'blah', nx: true, ex: 60)
+    assert_equal SidekiqSmartCache.redis.get('narf'), 'blah'
+    # confirm the expiration was set as expected
+    assert_equal SidekiqSmartCache.redis.ttl('narf'), 60
+
+    # returns false when its already set
+    refute SidekiqSmartCache.redis.set('narf', 'bunk', nx: true)
+    assert_equal SidekiqSmartCache.redis.get('narf'), 'blah'
+
+    # another way of making a key expire
+    assert SidekiqSmartCache.redis.set('blah', 'bart') && SidekiqSmartCache.redis.expire('blah', 42)
+    assert_equal SidekiqSmartCache.redis.ttl('blah'), 42
+
+  end
+
+  test 'brpop' do
+    SidekiqSmartCache.redis.lpush('narf', 'bunk')
+    duration = Benchmark.realtime do
+      assert_equal SidekiqSmartCache.redis.brpop('narf', timeout: 2), %w[narf bunk]
+    end
+    assert_includes 0.0..0.1, duration, 'Should finish immediately'
+
+    duration = Benchmark.realtime do
+      refute SidekiqSmartCache.redis.brpop('narf', timeout: 2) # returns nil on timeout
+    end
+    assert_includes 1.5..2.5, duration, 'Should time out'
+  end
+end


### PR DESCRIPTION
As of sidekiq 7.2, the redis objects supplied by the connection pool don't like syntax like `set('foo', 'bar', ex: true)` and bail with an error like:

```
TypeError:
       Unsupported command argument type: TrueClass
```

Instead we need to pass in array style arguments:
```
redis.call('SET', 'FOO', 'BAR', 'EX')
```

This adds support for that while keeping support for sidekiq 6 and 7.{0,1}.

Along the way we swtich from relying on `method_missing` to explicitly defined methods in the `SidekiqSmartCache::Redis` class. Performs oh-so-slightly better, and ditches that unsightly `method_missing`.