### PR TITLE
Add ruby 3.2 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         sidekiq: [ sidekiq6, sidekiq7, sidekiq7.2 ]
-        ruby: [ 2.7.5, 3.0.3 ]
+        ruby: [ 2.7.5, 3.0.3, 3.2.0 ]
     runs-on: ubuntu-latest
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/Gemfile-${{ matrix.sidekiq }}

--- a/gemfiles/Gemfile-sidekiq6
+++ b/gemfiles/Gemfile-sidekiq6
@@ -14,5 +14,5 @@ group :development, :test do
   gem 'railties', '~> 6.0.6', '>= 6.0.6.1'
 
   # To use a debugger
-  gem 'pry'
+  gem 'pry', '>= 0.14.2'
 end

--- a/gemfiles/Gemfile-sidekiq6.lock
+++ b/gemfiles/Gemfile-sidekiq6.lock
@@ -32,7 +32,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
-    coderay (1.1.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     connection_pool (2.2.2)
     crass (1.0.6)
@@ -42,7 +42,7 @@ GEM
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
     nokogiri (1.14.3)
@@ -50,9 +50,9 @@ GEM
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
       racc (~> 1.4)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.6.2)
     rack (2.2.3)
     rack-protection (2.0.8.1)
@@ -90,7 +90,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 6.0.6, >= 6.0.6.1)
-  pry
+  pry (>= 0.14.2)
   railties (~> 6.0.6, >= 6.0.6.1)
   sidekiq_smart_cache!
   sqlite3

--- a/gemfiles/Gemfile-sidekiq7
+++ b/gemfiles/Gemfile-sidekiq7
@@ -14,5 +14,5 @@ group :development, :test do
   gem 'railties', '~> 6.0.6', '>= 6.0.6.1'
 
   # To use a debugger
-  gem 'pry'
+  gem 'pry', '>= 0.14.2'
 end

--- a/gemfiles/Gemfile-sidekiq7.lock
+++ b/gemfiles/Gemfile-sidekiq7.lock
@@ -32,7 +32,7 @@ GEM
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     builder (3.2.4)
-    coderay (1.1.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     connection_pool (2.4.0)
     crass (1.0.6)
@@ -42,15 +42,15 @@ GEM
     loofah (2.20.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    method_source (0.9.2)
+    method_source (1.0.0)
     mini_portile2 (2.8.2)
     minitest (5.18.0)
     nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     racc (1.6.2)
     rack (2.2.6.4)
     rack-test (2.1.0)
@@ -86,7 +86,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 6.0.6, >= 6.0.6.1)
-  pry
+  pry (>= 0.14.2)
   railties (~> 6.0.6, >= 6.0.6.1)
   sidekiq_smart_cache!
   sqlite3

--- a/lib/sidekiq_smart_cache/result.rb
+++ b/lib/sidekiq_smart_cache/result.rb
@@ -18,7 +18,7 @@ class Result
 
   def self.load_from(cache_tag)
     raw = redis.get(cache_tag)
-    new(YAML.safe_load(raw, allowed_classes)) if raw
+    new(YAML.safe_load(raw, permitted_classes: allowed_classes)) if raw
   end
 
   def initialize(result)

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -4,22 +4,23 @@
 #   Ensure the SQLite 3 gem is defined in your Gemfile
 #   gem 'sqlite3'
 #
-default: &default
+development:
   adapter: sqlite3
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   timeout: 5000
-
-development:
-  <<: *default
   database: db/development.sqlite3
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
   database: db/test.sqlite3
 
 production:
-  <<: *default
+  adapter: sqlite3
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  timeout: 5000
   database: db/production.sqlite3

--- a/test/result_test.rb
+++ b/test/result_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class ResultTest < ActiveSupport::TestCase
+  setup do
+    SidekiqSmartCache.redis.flushdb
+  end
+
+  test 'storing and retrieving string result' do
+    assert_nil Result.load_from('narf')
+    Result.persist('narf', 'blah', 10.seconds)
+    result = Result.load_from('narf')
+    assert result.fresh?
+    refute result.stale?
+    assert_equal result.value, 'blah'
+  end
+end


### PR DESCRIPTION
Ruby 3.2 includes the new `Psych 4` YAML parser.  

It has a subtly different API.  Compatible enough at least as far back as we need to support.